### PR TITLE
Add page: Astro Slide boot modes

### DIFF
--- a/wiki/Astro-boot-modes.md
+++ b/wiki/Astro-boot-modes.md
@@ -1,0 +1,39 @@
+# Astro boot modes
+
+The button combos to access the various boot modes of the Astro Slide are listed here.
+
+For Gemini/Cosmo boot mode button combos, see the [Bootloader page on the Gemian wiki](https://github.com/gemian/gemian/wiki/Bootloader).
+
+## Normal boot
+
+Hold Power/Esc. When the device vibrates, release Power/Esc.
+
+Note that if you've unlocked the bootloader, you'll need to press again to continue when prompted.
+
+## Force a reboot
+
+Hold Power/Esc. When the device vibrates, release Power/Esc.
+
+## View charging state while powered down
+
+While the device is powered down and charging, you can briefly show the screen displaying the graphical battery percentage by pressing the power button or Esc key.
+
+## Recovery
+
+Hold Power/Esc + Volume Up. When the device vibrates, release Power/Esc. When the screen turns on, release Volume Up.
+
+After the bootloader screen, an Android graphic appears along with 'No command' in tiny writing.
+
+Briefly press Power + Volume Up to display the menu.
+
+## Fastboot
+
+Hold Power/Esc + Volume Down. When the device vibrates, release Power/Esc. When the screen turns on, release Volume Down.
+
+'Fastboot mode...' appears at the bottom of the (portrait) screen in tiny writing.
+
+Note that fastboot can also be accessed from recovery, but looks different.
+
+## Safe mode
+
+We do not yet know of a way to boot Android in safe mode.


### PR DESCRIPTION
I thought this would be useful to document, especially given the differences from the Gemini and Cosmo.

It could be worth combining this with the [Gemian wiki's Bootloader page](https://github.com/gemian/gemian/wiki/Bootloader) (I think here could be a better home); but I've just added a link for now. It'd be good to link back from there too.