### PR TITLE
Link to the wikis in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # README
 
-This repository acts as an intermediary staging area for new content, modifications, and updates to the [planet-devices][] repository's wiki.
+This repository acts as an intermediary staging area for new content, modifications, and updates to the [planet-devices][] repository's [wiki][community-wiki].
 
-It is hoped that in the future, we'll be able to merge the Planet Computers' support wiki, and community wiki together, to have a true open source, Git-backed knowledge base.
+It is hoped that in the future, we'll be able to merge the [Planet Computers' support wiki][support-wiki], and [community wiki][community-wiki] together, to have a true open source, Git-backed knowledge base.
 
 However, for now, this repository, and [planet-devices][] remain a community-maintained initiative.
 
 [planet-devices]: https://github.com/shymega/planet-devices
+[community-wiki]: https://github.com/shymega/planet-devices/wiki
+[support-wiki]: https://support.planetcom.co.uk


### PR DESCRIPTION
I kept having to edit my browser URL to navigate from this repo to the wiki. Having an actual link will make that easier. I've added a link to the official wiki while I was at it.

It'd also be good to set this repo's URL property to the wiki URL.