### PR TITLE
Update Astro rooting page for firmware V07, adding A/B slot instructions

### DIFF
--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -56,11 +56,11 @@ This method is the easiest, but relies on someone having already published the a
 
 - Download the rooted boot image matching your OS version (see Settings -> About phone -> Build number). These rooted boot images were generated using the method: 'Patch the boot image yourself using the Magisk app on Android'
     + V01 (`Astro-11.0-Planet-05182022-V01`)
-        * [stock](https://mega.nz/file/QgNEAKDC#obAvEFHSEloNim_xuLPFRgFxFTaYLYYR7HVXjKC9WVw) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
-        * [rooted](https://mega.nz/file/A1kmzAIS#vf1k1CE15O6IVxcreNapqcSWpO-sgNhoIaPVPlhNM9A) (md5: `59ea27307b69ad03fb0e882f60d4c7a0`)
+        * [stock](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v01-stock.img) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v01-magisk-from-app.img) (md5: `59ea27307b69ad03fb0e882f60d4c7a0`)
     + V07 (`Astro-11.0-Planet-05192023-V07`)
-        * [stock](https://mega.nz/file/gpV3QaSJ#7I6t6ttwNR3QrrN38DKp_HCO4A8z58IFkXITyrdXxdg) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
-        * [rooted](https://mega.nz/file/hgVAnJbT#gbmsg4zY2DfTsVa3WdfhEvpDf6antASBcfFPCmna20A) (md5: `2addcb10e94985aea3b9a9527016931f`)
+        * [stock](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07-magisk-from-app-26100.img) (md5: `2addcb10e94985aea3b9a9527016931f`)
 - Reboot to fastboot - run: `adb reboot fastboot`
 - Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07-magisk-from-app-26100.img`
 - Reboot: `fastboot reboot`

--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -19,6 +19,23 @@ Use the Astro's bottom/right USB port to connect to your computer.
 
 You can perform the bootloader unlock by following [this iFixit guide](https://www.ifixit.com/Guide/How+to+unlock+the+bootloader+of+an+Android+Phone/152629).
 
+## Find out which slot is currently in use
+
+Android on the Astro uses [Virtual A/B](https://source.android.com/docs/core/ota/virtual_ab) for its OS update mechanism. This means key partitions each have an A and B slot, e.g. `boot_a` and `boot_b`. Only one slot is in use at a time (i.e. all of the `*_a` partitions, or all of the `*_b` partitions), and which slot is active switches over after an OS update is installed to the inactive slot.
+
+To find out which slot you need to operate on for the rest of this guide:
+
+- Reboot to fastboot - run: `adb reboot fastboot`
+- Query the current slot: `fastboot getvar current-slot`
+
+This will output something like:
+
+```
+current-slot: b
+```
+
+**The rest of this document assumes the current slot is A. If it's B, be sure to replace all instances of `_a` with `_b`!**
+
 ## Extract (back up) the stock boot image from the Astro
 
 It is strongly recommended to make a backup of your stock boot image, as you'll need to restore it before performing an OTA OS update.
@@ -38,15 +55,20 @@ Note that there have been reports of Linux being the easiest OS to get MTKClient
 This method is the easiest, but relies on someone having already published the applicable rooted boot image here, and having to trust that it is not malicious.
 
 - Download the rooted boot image matching your OS version (see Settings -> About phone -> Build number). These rooted boot images were generated using the method: 'Patch the boot image yourself using the Magisk app on Android'
-    + V01 (`Astro-11.0-Planet-05182022-V01`) - [stock](https://mega.nz/file/QgNEAKDC#obAvEFHSEloNim_xuLPFRgFxFTaYLYYR7HVXjKC9WVw), [rooted](https://mega.nz/file/A1kmzAIS#vf1k1CE15O6IVxcreNapqcSWpO-sgNhoIaPVPlhNM9A)
+    + V01 (`Astro-11.0-Planet-05182022-V01`)
+        * [stock](https://mega.nz/file/QgNEAKDC#obAvEFHSEloNim_xuLPFRgFxFTaYLYYR7HVXjKC9WVw) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
+        * [rooted](https://mega.nz/file/A1kmzAIS#vf1k1CE15O6IVxcreNapqcSWpO-sgNhoIaPVPlhNM9A) (md5: `59ea27307b69ad03fb0e882f60d4c7a0`)
+    + V07 (`Astro-11.0-Planet-05192023-V07`)
+        * [stock](https://mega.nz/file/gpV3QaSJ#7I6t6ttwNR3QrrN38DKp_HCO4A8z58IFkXITyrdXxdg) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
+        * [rooted](https://mega.nz/file/hgVAnJbT#gbmsg4zY2DfTsVa3WdfhEvpDf6antASBcfFPCmna20A) (md5: `2addcb10e94985aea3b9a9527016931f`)
 - Reboot to fastboot - run: `adb reboot fastboot`
-- Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v01-magisk-from-app.img`
+- Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07-magisk-from-app-26100.img`
 - Reboot: `fastboot reboot`
 
 ### Rooting method 2: Patch the boot image yourself using the Magisk app on Android
 
 - Copy the stock boot image file onto the Astro's storage
-- Download and install the Magisk app on the Astro (be sure to only ever download it from the [official Magisk GitHub](https://github.com/topjohnwu/Magisk)). Get the full APK of the latest version from the [Releases page](https://github.com/topjohnwu/Magisk/releases), e.g. `Magisk-v25.2.apk`
+- Download and install the Magisk app on the Astro (be sure to only ever download it from the [official Magisk GitHub](https://github.com/topjohnwu/Magisk)). Get the full APK of the latest version from the [Releases page](https://github.com/topjohnwu/Magisk/releases), e.g. `Magisk-v26.1.apk`
 - Open the Magisk app
 - Tap 'Install' in the 'Magisk' card
 - Tap 'Select and Patch a File'


### PR DESCRIPTION
I've added the new boot images, and annotated MD5 hashes for all of them. I'm now appending the Magisk version to the filename, as there was an update since the first image was produced.

Adding instructions for determining which A/B slot's in use is now necessary, since it's no longer always going to be A.

Resolves https://github.com/shymega/planet-devices-wiki-prs/issues/17.