### PR TITLE
Fix typo in image hotlink (PR #31)

### DIFF
--- a/wiki/Astro-battery-optimisation.md
+++ b/wiki/Astro-battery-optimisation.md
@@ -17,7 +17,7 @@ Most apps don't give you any benefit from running in the background, while they 
 
 Go to Settings, and then look for "DuraSpeed" near the bottom of the list:
 
-[[img/duraspeed.png|A screenshot showing DuraSpeed in settings.]]
+[[img/duraspeed.jpg|A screenshot showing DuraSpeed in settings.]]
 
 Find the app that you want to be able to run in the background, and **enable** it.
 


### PR DESCRIPTION
This was because I entered the first image's link manually. My mistake. I should have kept the original line.