### PR TITLE
Astro rooting: Fixes for updated boot images

### DIFF
--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -56,14 +56,14 @@ This method is the easiest, but relies on someone having already published the a
 
 - Download the rooted boot image matching your OS version (see Settings -> About phone -> Build number). These rooted boot images were generated using the method: 'Patch the boot image yourself using the Magisk app on Android'
     + V01 (`Astro-11.0-Planet-05182022-V01`)
-        * [stock](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v01-stock.img) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v01-magisk-from-app-26300.img) (md5: `b897242ab79dd2accc7d38245c8d3eb7`)
+        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v01-stock.img) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v01-magisk-from-app-26300.img) (md5: `b897242ab79dd2accc7d38245c8d3eb7`)
     + V07 (`Astro-11.0-Planet-05192023-V07`)
-        * [stock](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
+        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
     + V07b (`Astro-11.0-Planet-05242023-V07b`)
-        * [stock](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07b-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/9aa7a0f4324eee11fe8196d5727c13fc48b68b6e/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
+        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
 -
 - Reboot to fastboot - run: `adb reboot fastboot`
 - Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07-magisk-from-app-26100.img`

--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -64,7 +64,6 @@ This method is the easiest, but relies on someone having already published the a
     + V07b (`Astro-11.0-Planet-05242023-V07b`)
         * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
         * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
--
 - Reboot to fastboot - run: `adb reboot fastboot`
 - Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07-magisk-from-app-26100.img`
 - Reboot: `fastboot reboot`

--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -65,7 +65,7 @@ This method is the easiest, but relies on someone having already published the a
         * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
         * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
 - Reboot to fastboot - run: `adb reboot fastboot`
-- Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07-magisk-from-app-26100.img`
+- Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07b-magisk-from-app-26300.img`
 - Reboot: `fastboot reboot`
 
 ### Rooting method 2: Patch the boot image yourself using the Magisk app on Android


### PR DESCRIPTION
I noticed that most of the links to the boot images were broken - due to the files in the project and link URLs being renamed (in https://github.com/shymega/planet-devices/commit/f223dd6f049045ba3042490d34c481454de9af71 and https://github.com/shymega/planet-devices-wiki-prs/pull/40, respectively), but the updated files were not available at the original commit. I've fixed the URLs by updating the hardcoded commit SHA to the latest.

I've now tested that all these image file links actually download something, and that the checksums are correct.

Avoiding this problem was one of the reasons I'd [suggested not hardcoding a commit SHA](https://github.com/shymega/planet-devices-wiki-prs/pull/23#issuecomment-1567491378) =P

I've also removed a blank dot point; and updated the filename used in a flashing example, since the original filename no longer exists in the list of images.

---

Sidenote: confusingly, in https://github.com/shymega/planet-devices/commit/f223dd6f049045ba3042490d34c481454de9af71, Git/GitHub shows the v01 magisk image having been renamed to the v07b magisk image:
![image](https://github.com/shymega/planet-devices-wiki-prs/assets/2916331/9ab47320-3022-4e91-b484-182ddadf183e)
But it must be getting confused by the files being similar, as the diff of md5s disproves a rename:
![image](https://github.com/shymega/planet-devices-wiki-prs/assets/2916331/8deb59fe-0d9e-4f99-bad4-79b5f39d9d0f)