### PR TITLE
Fix Astro v07b boot images

### DIFF
--- a/wiki/Astro-rooting.md
+++ b/wiki/Astro-rooting.md
@@ -56,14 +56,14 @@ This method is the easiest, but relies on someone having already published the a
 
 - Download the rooted boot image matching your OS version (see Settings -> About phone -> Build number). These rooted boot images were generated using the method: 'Patch the boot image yourself using the Magisk app on Android'
     + V01 (`Astro-11.0-Planet-05182022-V01`)
-        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v01-stock.img) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v01-magisk-from-app-26300.img) (md5: `b897242ab79dd2accc7d38245c8d3eb7`)
+        * [stock](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v01-stock.img) (md5: `936703a76c8ddd860f2b84b69ae7c951`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v01-magisk-from-app-26300.img) (md5: `b897242ab79dd2accc7d38245c8d3eb7`)
     + V07 (`Astro-11.0-Planet-05192023-V07`)
-        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
+        * [stock](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v07-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v07-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
     + V07b (`Astro-11.0-Planet-05242023-V07b`)
-        * [stock](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-stock.img) (md5: `bfa1c0914e8143a2d3cbf9e26a7ad0f6`)
-        * [rooted](https://github.com/shymega/planet-devices/raw/f223dd6f049045ba3042490d34c481454de9af71/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `bdb8066ad8d3b823dc494b420571fcad`)
+        * [stock](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v07b-stock.img) (md5: `629a31624bb4486f64d00daa321188f1`)
+        * [rooted](https://github.com/shymega/planet-devices/raw/4d550edbe1ff4c501f2c01ada64d4905b61b0a62/resources/boot-images/astro/boot-v07b-magisk-from-app-26300.img) (md5: `533b50635ef356674ff059341e23c40d`)
 - Reboot to fastboot - run: `adb reboot fastboot`
 - Flash the image to the Astro - run e.g.: `fastboot flash boot boot-v07b-magisk-from-app-26300.img`
 - Reboot: `fastboot reboot`


### PR DESCRIPTION
Resolves https://github.com/shymega/planet-devices-wiki-prs/issues/39.

Depends on https://github.com/shymega/planet-devices/pull/78.

TL;DR: The V07b boot images originally added to the wiki in https://github.com/shymega/planet-devices-wiki-prs/pull/40 were mistaken duplicates of V07, as the boot image had been mistakely read from the inactive slot.

## Full context from [`#dev` on the Astro Slide Discord](https://discord.com/channels/798562411421499392/984151635301367818/1155013075427135590)

ZimbiX — 23/09/2023 15:29

> I've finally just upgraded my Astro from V07 to V07b (using 'Rooting method 2: Patch the boot image yourself using the Magisk app on Android'). I'm seeing different images/checksums for the stock and rooted boot images to what's on the wiki: https://github.com/shymega/planet-devices/wiki/Astro-rooting
> 
> ﻿[@]shymega [@]diejuse It seems unlikely for two people to get it wrong, but are you folks absolutely sure you read from the correct boot slot? (After applying the OTA, run `fastboot getvar current-slot`, as instructed at the top of the wiki page, since the active slot will have just changed. My active slot is now slot A). When the wiki was being updated for V07b, I had been surprised to hear that the boot image was unchanged from V07 - the OTA's changelog is tiny, but it seemed to be quite a big OTA download.
> ﻿
> From the wiki:
> 
> ```
> ➜ md5sum ~/Downloads/boot-v07b-*                                           
> bdb8066ad8d3b823dc494b420571fcad  /home/brendan/Downloads/boot-v07b-magisk-from-app-26300.img
> bfa1c0914e8143a2d3cbf9e26a7ad0f6  /home/brendan/Downloads/boot-v07b-stock.img
> ```
> 
> From reading and patching it myself:
> 
> ```
> ➜ md5sum ~/Dropbox/Android/Astro\ Slide/boot-v07b-*                        
> 533b50635ef356674ff059341e23c40d  /home/brendan/Dropbox/Android/Astro Slide/boot-v07b-magisk-from-app-26300.img
> 629a31624bb4486f64d00daa321188f1  /home/brendan/Dropbox/Android/Astro Slide/boot-v07b-stock.img
> ```
> 
> All the images are the same size - 41,943,040 bytes - so I don't think partition size/trimming is the problem.
> 
> I wanted to again make a full device backup with mtkclient before updating (`mtk rl <dir>`) just in case, but I had some trouble getting mtkclient working again after pulling the latest commits. I'm also on a different machine to last time (but I just moved my disk over to my gaming PC after my laptop fan died). I did eventually get it 'working' on the latest commit (c638911) - it logs an error after reading each partition, but the image files seem to have been produced just fine. Before I did the OTA or flashed anything, I verified from my full device backup that the rooted V07 boot image had indeed been readback correctly. So I'm pretty confused!
> 
> I haven't used Python apps much before. My issue with mtkclient was around its dependencies and incompatible data in the .state file. I'd got it 'working' in the end with:
> 
> ```
> rm -rf .state logs venv
> python -m venv venv
> venv/bin/pip install -r requirements.txt
> time venv/bin/python ./mtk rl <dir>
> ```
> 
> Here's what that looks like: 
> 
> ```
> ➜ rm -rf .state logs venv && python -m venv venv && venv/bin/pip install -r requirements.txt && time venv/bin/python ./mtk rl derp
> Collecting wheel>=0.37.1 (from -r requirements.txt (line 1))
>   Obtaining dependency information for wheel>=0.37.1 from https://files.pythonhosted.org/packages/b8/8b/31273bf66016be6ad22bb7345c37ff350276cfd46e389a0c2ac5da9d9073/wheel-0.41.2-py3-none-any.whl.metadata
>   Using cached wheel-0.41.2-py3-none-any.whl.metadata (2.2 kB)
> Collecting pyusb>=1.2.1 (from -r requirements.txt (line 2))
>   Using cached pyusb-1.2.1-py3-none-any.whl (58 kB)
> Collecting pycryptodome>=3.15.0 (from -r requirements.txt (line 3))
>   Obtaining dependency information for pycryptodome>=3.15.0 from https://files.pythonhosted.org/packages/00/e6/73931df4046e34a6354d323b4a5b5c18e5184f4a08687806ee3353c81a6b/pycryptodome-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
>   Using cached pycryptodome-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.4 kB)
> Collecting pycryptodomex (from -r requirements.txt (line 4))
>   Obtaining dependency information for pycryptodomex from https://files.pythonhosted.org/packages/23/23/3f3d042c96ff7bece5b126365593b1f9c8e3ae62ce80d44e9da39c5e8a73/pycryptodomex-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata
>   Using cached pycryptodomex-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.4 kB)
> Collecting colorama>=0.4.4 (from -r requirements.txt (line 5))
>   Using cached colorama-0.4.6-py2.py3-none-any.whl (25 kB)
> Collecting shiboken6>=6.4.0.1 (from -r requirements.txt (line 6))
>   Obtaining dependency information for shiboken6>=6.4.0.1 from https://files.pythonhosted.org/packages/55/44/d8c366dd4f069166ab9890acb44d004c5e6122714e44c169273dcbbca897/shiboken6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata
>   Using cached shiboken6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (2.3 kB)
> Collecting pyside6>=6.4.0.1 (from -r requirements.txt (line 7))
>   Obtaining dependency information for pyside6>=6.4.0.1 from https://files.pythonhosted.org/packages/60/4d/4ccb1e1c58d62da887c7fe881cdaa80fc1ea07057af8edb6c4cc50b33704/PySide6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata
>   Using cached PySide6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (5.1 kB)
> Collecting mock>=4.0.3 (from -r requirements.txt (line 8))
>   Obtaining dependency information for mock>=4.0.3 from https://files.pythonhosted.org/packages/6b/20/471f41173930550f279ccb65596a5ac19b9ac974a8d93679bcd3e0c31498/mock-5.1.0-py3-none-any.whl.metadata
>   Using cached mock-5.1.0-py3-none-any.whl.metadata (3.0 kB)
> Collecting pyserial>=3.5 (from -r requirements.txt (line 9))
>   Using cached pyserial-3.5-py2.py3-none-any.whl (90 kB)
> Collecting PySide6-Essentials==6.5.2 (from pyside6>=6.4.0.1->-r requirements.txt (line 7))
>   Obtaining dependency information for PySide6-Essentials==6.5.2 from https://files.pythonhosted.org/packages/d0/de/9a089e91c2e0fe4f122218bba4f9dbde46338659f412739bd9db1ed9df4f/PySide6_Essentials-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata
>   Using cached PySide6_Essentials-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (3.5 kB)
> Collecting PySide6-Addons==6.5.2 (from pyside6>=6.4.0.1->-r requirements.txt (line 7))
>   Obtaining dependency information for PySide6-Addons==6.5.2 from https://files.pythonhosted.org/packages/28/d6/c1826931f8a56b17650f8fe12db6ebbf308bf60aa9553b50c20a967eeb78/PySide6_Addons-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata
>   Using cached PySide6_Addons-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl.metadata (3.7 kB)
> Using cached wheel-0.41.2-py3-none-any.whl (64 kB)
> Using cached pycryptodome-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
> Using cached pycryptodomex-3.19.0-cp35-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.1 MB)
> Using cached shiboken6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl (174 kB)
> Using cached PySide6-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl (6.7 kB)
> Using cached PySide6_Addons-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl (126.3 MB)
> Using cached PySide6_Essentials-6.5.2-cp37-abi3-manylinux_2_28_x86_64.whl (81.2 MB)
> Using cached mock-5.1.0-py3-none-any.whl (30 kB)
> Installing collected packages: pyserial, wheel, shiboken6, pyusb, pycryptodomex, pycryptodome, mock, colorama, PySide6-Essentials, PySide6-Addons, pyside6
> Successfully installed PySide6-Addons-6.5.2 PySide6-Essentials-6.5.2 colorama-0.4.6 mock-5.1.0 pycryptodome-3.19.0 pycryptodomex-3.19.0 pyserial-3.5 pyside6-6.5.2 pyusb-1.2.1 shiboken6-6.5.2 wheel-0.41.2
> MTK Flash/Exploit Client V1.6.3 (c) B.Kerler 2018-2023
> 
> Preloader - Status: Waiting for PreLoader VCOM, please connect mobile
> 
> Port - Hint:
> 
> Power off the phone before connecting.
> For brom mode, press and hold vol up, vol dwn, or all hw buttons and connect usb.
> For preloader mode, don't press any hw button and connect usb.
> If it is already connected and on, hold power for 10 seconds to reset.
> 
> 
> ...........
> 
> Port - Hint:
> 
> Power off the phone before connecting.
> For brom mode, press and hold vol up, vol dwn, or all hw buttons and connect usb.
> For preloader mode, don't press any hw button and connect usb.
> If it is already connected and on, hold power for 10 seconds to reset.
> 
> 
> ..Port - Device detected :)
> Preloader - 	CPU:			MT6873(Dimensity 800/820 5G)
> Preloader - 	HW version:		0x0
> Preloader - 	WDT:			0x10007000
> Preloader - 	Uart:			0x11002000
> Preloader - 	Brom payload addr:	0x100a00
> Preloader - 	DA payload addr:	0x201000
> Preloader - 	CQ_DMA addr:		0x10212000
> Preloader - 	Var1:			0xa
> Preloader - Disabling Watchdog...
> Preloader - HW code:			0x886
> Preloader - Target config:		0x0
> Preloader - 	SBC enabled:		False
> Preloader - 	SLA enabled:		False
> Preloader - 	DAA enabled:		False
> Preloader - 	SWJTAG enabled:		False
> Preloader - 	EPP_PARAM at 0x600 after EMMC_BOOT/SDMMC_BOOT:	False
> Preloader - 	Root cert required:	False
> Preloader - 	Mem read auth:		False
> Preloader - 	Mem write auth:		False
> Preloader - 	Cmd 0xC8 blocked:	False
> Preloader - Get Target info
> Preloader - 	HW subcode:		0x8a00
> Preloader - 	HW Ver:			0xca00
> Preloader - 	SW Ver:			0x0
> DA_handler - Device is unprotected.
> DA_handler - Device is in Preloader-Mode :(
> DAXFlash - Uploading xflash stage 1 from MTK_AllInOne_DA_5.2228.bin
> xflashext - Patching da1 ...
> Mtk - Patched "Patched loader msg" in preloader
> Mtk - Patched "hash_check" in preloader
> xflashext
> xflashext - [LIB]: Error on patching da1 version check...
> Mtk - Patched "Patched loader msg" in preloader
> Mtk - Patched "get_vfy_policy" in preloader
> xflashext - Patching da2 ...
> DAXFlash - Successfully uploaded stage 1, jumping ..
> Preloader - Jumping to 0x200000
> Preloader - Jumping to 0x200000: ok.
> DAXFlash - Successfully received DA sync
> DAXFlash - Uploading stage 2...
> DAXFlash - Upload data was accepted. Jumping to stage 2...
> DAXFlash - Successfully uploaded stage 2
> DAXFlash - UFS Blocksize:0x1000
> DAXFlash - UFS ID:       H9HQ15AFAMADAR
> DAXFlash - UFS MID:      0xad
> DAXFlash - UFS CID:      ad014839485131354146414d41444152
> DAXFlash - UFS FWVer:    41313032
> DAXFlash - UFS Serial:   313131433734353738314541
> DAXFlash - UFS LU0 Size: 0x1dcb000000
> DAXFlash - UFS LU1 Size: 0x400000
> DAXFlash - UFS LU2 Size: 0x400000
> DAXFlash - HW-CODE         : 0x886
> DAXFlash - HWSUB-CODE      : 0x8A00
> DAXFlash - HW-VERSION      : 0xCA00
> DAXFlash - SW-VERSION      : 0x0
> DAXFlash - CHIP-EVOLUTION  : 0x1
> DAXFlash - DA-VERSION      : 1.0
> DAXFlash - Extensions were accepted. Jumping to extensions...
> DAXFlash - DA Extensions successfully added
> DA_handler - Dumping partition misc with sector count 128 as derp/misc.bin.
> Progress: |██████████████████████████████████████████████████| 100.0% Read (Sector 0x400 of 0x400, ) 33.51 MB/s
> DA_handler
> DA_handler - [LIB]: Failed to dump partition misc as derp/misc.bin.
> DA_handler - Dumping partition para with sector count 128 as derp/para.bin.
> Progress: |██████████████████████████████████████████████████| 100.0% Read (Sector 0x400 of 0x400, ) 32.63 MB/s
> DA_handler
> DA_handler - [LIB]: Failed to dump partition para as derp/para.bin.
> DA_handler - Dumping partition expdb with sector count 5120 as derp/expdb.bin.
> Progress: |██████████████████████████████████████████████████| 100.0% Read (Sector 0xA000 of 0xA000, ) 33.52 MB/s MB/s
> DA_handler
> DA_handler - [LIB]: Failed to dump partition expdb as derp/expdb.bin.
> DA_handler - Dumping partition frp with sector count 256 as derp/frp.bin.
> Progress: |██████████████████████████████████████████████████| 100.0% Read (Sector 0x800 of 0x800, ) 32.66 MB/s
> DA_handler
> ```
> 
> etc
> 
> Logs TL;DR:
> 
> ```
> DA_handler - [LIB]: Failed to dump partition misc as derp/misc.bin.
> ```
> 
> It's a similar but different error when reading just one partition.
> The last line logged is:
> 
> ```
> DA_handler - Failed to dump sector 144640 with sector count 10240 as derp.
> ```
> 
> It's a similar but different error when reading just one partition.
> 
> ```
> ➜ venv/bin/python ./mtk r boot_a derp
> MTK Flash/Exploit Client V1.6.3 (c) B.Kerler 2018-2023
> 
> Preloader - Status: Waiting for PreLoader VCOM, please connect mobile
> 
> Port - Hint:
> 
> Power off the phone before connecting.
> For brom mode, press and hold vol up, vol dwn, or all hw buttons and connect usb.
> For preloader mode, don't press any hw button and connect usb.
> If it is already connected and on, hold power for 10 seconds to reset.
> 
> 
> ........Port - Device detected :)
> Preloader - 	CPU:			MT6873(Dimensity 800/820 5G)
> Preloader - 	HW version:		0x0
> Preloader - 	WDT:			0x10007000
> Preloader - 	Uart:			0x11002000
> Preloader - 	Brom payload addr:	0x100a00
> Preloader - 	DA payload addr:	0x201000
> Preloader - 	CQ_DMA addr:		0x10212000
> Preloader - 	Var1:			0xa
> Preloader - Disabling Watchdog...
> Preloader - HW code:			0x886
> Preloader - Target config:		0x0
> Preloader - 	SBC enabled:		False
> Preloader - 	SLA enabled:		False
> Preloader - 	DAA enabled:		False
> Preloader - 	SWJTAG enabled:		False
> Preloader - 	EPP_PARAM at 0x600 after EMMC_BOOT/SDMMC_BOOT:	False
> Preloader - 	Root cert required:	False
> Preloader - 	Mem read auth:		False
> Preloader - 	Mem write auth:		False
> Preloader - 	Cmd 0xC8 blocked:	False
> Preloader - Get Target info
> Preloader - 	HW subcode:		0x8a00
> Preloader - 	HW Ver:			0xca00
> Preloader - 	SW Ver:			0x0
> DA_handler - Device is unprotected.
> DA_handler - Device is in Preloader-Mode :(
> DAXFlash - Uploading xflash stage 1 from MTK_AllInOne_DA_5.2228.bin
> xflashext - Patching da1 ...
> Mtk - Patched "Patched loader msg" in preloader
> Mtk - Patched "hash_check" in preloader
> xflashext
> xflashext - [LIB]: Error on patching da1 version check...
> Mtk - Patched "Patched loader msg" in preloader
> Mtk - Patched "get_vfy_policy" in preloader
> xflashext - Patching da2 ...
> DAXFlash - Successfully uploaded stage 1, jumping ..
> Preloader - Jumping to 0x200000
> Preloader - Jumping to 0x200000: ok.
> DAXFlash - Successfully received DA sync
> DAXFlash - Uploading stage 2...
> DAXFlash - Upload data was accepted. Jumping to stage 2...
> DAXFlash - Successfully uploaded stage 2
> DAXFlash - UFS Blocksize:0x1000
> DAXFlash - UFS ID:       H9HQ15AFAMADAR
> DAXFlash - UFS MID:      0xad
> DAXFlash - UFS CID:      ad014839485131354146414d41444152
> DAXFlash - UFS FWVer:    41313032
> DAXFlash - UFS Serial:   313131433734353738314541
> DAXFlash - UFS LU0 Size: 0x1dcb000000
> DAXFlash - UFS LU1 Size: 0x400000
> DAXFlash - UFS LU2 Size: 0x400000
> DAXFlash - HW-CODE         : 0x886
> DAXFlash - HWSUB-CODE      : 0x8A00
> DAXFlash - HW-VERSION      : 0xCA00
> DAXFlash - SW-VERSION      : 0x0
> DAXFlash - CHIP-EVOLUTION  : 0x1
> DAXFlash - DA-VERSION      : 1.0
> DAXFlash - Extensions were accepted. Jumping to extensions...
> DAXFlash - DA Extensions successfully added
> DA_handler - Requesting available partitions ....
> DA_handler - Dumping partition "boot_a"
> Progress: |██████████████████████████████████████████████████| 100.0% Read (Sector 0x14000 of 0x14000, ) 32.83 MB/s7 MB/s
> DA_handler - Failed to dump sector 144640 with sector count 10240 as derp.
> ```

Dom (shymega) — 26/09/2023 09:36

> I could well have gotten the boot image from the wrong slot. I'm testing now, I'll need to go to bed shortly
> Hm, that's strange. Fastboot isn't registering.
> OK, so I get the slot as 'a'
> I read from mtkclient the 'boot' slot, so that should be set to 'a'. I didn't explicitly set it.

Dom (shymega) — 26/09/2023 09:39

> The error with this is that you need to use v1.52. I've got a edit for the wiki on that. mtkclient from Git is broken.
> ~~Unless, you are using v1.52, and this is a new error. But didn't someone here manage to do a full dump?~~
> EDIT: I saw you mentioned you 'pulled the latest commits'. That's the issue. It's broken.
> [@]ZimbiX I checked on my Astro, I think mtkclient pulled from a funky partition. The wiki images are incorrect. I can, or if you want to (?), make a PR to update those images, with the patching from Magisk v26.3.
> Let me know though, so we don't both do it at the same time! 😅
> However, noting, me patching the v07b stock image with Magisk v26.3, does not produce the same MD5 hash as you have.

ZimbiX — 28/09/2023 15:40

> Does your v07b stock boot image MD5 match what I found, at least? Or do you no longer have your own copy? 
> Interesting - I just patched it again, and got a different hash than I posted above. Doing it again gave the same one again. Maybe the current date is encoded into a Magisk image.

Dom (shymega) — 28/09/2023 22:47

> Yes, so when I used mtkclient on boot_a, I got a matching stock boot image MD5.
> I think, so too.

ZimbiX — 28/09/2023 22:54

> Cool. Ok, let's fix the wiki. I'm going to bed, and can make a PR in the morning

(sorry, I had other things going on for a few days and forgot about this)